### PR TITLE
add support for toggling all subsequent unit translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ p {
   font-size: 32px;
   line-height: 1.2;
   letter-spacing: 1px; /* no */
+  /* postcss-px2units-disable */
+  box-shadow: 4px 4px 2px 2px #777;
+  /* postcss-px2units-enable */
+  padding: 8px;
 }
 
 /* output */
@@ -35,6 +39,8 @@ p {
   font-size: 32rpx;
   line-height: 1.2;
   letter-spacing: 1px;
+  box-shadow: 4px 4px 2px 2px #777;
+  padding: 8rpx;
 }
 ```
 
@@ -70,7 +76,9 @@ Default:
   multiple: 1,
   decimalPlaces: 2,
   comment: 'no',
-  targetUnits: 'rpx'
+  targetUnits: 'rpx',
+  disableAllComment: 'postcss-px2units-disable',
+  enableAllComment: 'postcss-px2units-enable'
 }
 ```
 
@@ -80,6 +88,8 @@ Detail:
 - multiple(Number): multiple, replace pixel value with pixel * multiple.
 - decimalPlaces(Number): the number of decimal places. For example, the css code is `width: 100px`, we will get the vaule is `Number(100 / divisor * multiple).toFixed(decimalPlaces)`.
 - comment(String): default value is 'no'. For example, if you set it 'not replace', the css code `width: 100px; /* not replace */` will be translated to `width: 100px;`
+- disableAllComment(String): comment value for disabling translation of subsequent declarations. Default value is 'postcss-px2units-disable'. If you set it to 'not replace all', `width: 100px; /* not replace all */ height: 50px;` will be translated to `width: 100rpx; height: 50px;`
+- enableAllComment(String): comment value for enabling translation of subsequent declarations. Default value is 'postcss-px2units-enable'. If you set it to 'replace all' and set disableAllComment to 'not replace all', `width: 100px; /* not replace all */ height: 50px; /* replace all */ margin: 10px;` will be translated to `width: 100rpx; height: 50px; margin: 10rpx;`
 - targetUnits(String): The units will replace pixel units, you can set it 'rem'.
 
 ### Use with gulp-postcss

--- a/README_CN.md
+++ b/README_CN.md
@@ -27,6 +27,10 @@ p {
   font-size: 32px;
   line-height: 1.2;
   letter-spacing: 1px; /* no */
+  /* postcss-px2units-disable */
+  box-shadow: 4px 4px 2px 2px #777;
+  /* postcss-px2units-enable */
+  padding: 8px;
 }
 
 /* output */
@@ -35,6 +39,8 @@ p {
   font-size: 32rpx;
   line-height: 1.2;
   letter-spacing: 1px;
+  box-shadow: 4px 4px 2px 2px #777;
+  padding: 8rpx;
 }
 ```
 
@@ -70,7 +76,9 @@ Default:
   multiple: 1,
   decimalPlaces: 2,
   comment: 'no',
-  targetUnits: 'rpx'
+  targetUnits: 'rpx',
+  disableAllComment: 'postcss-px2units-disable',
+  enableAllComment: 'postcss-px2units-enable'
 }
 ```
 
@@ -80,6 +88,8 @@ Detail:
 - multiple(Number): 倍数，转换后的值 等于 pixel * multiple
 - decimalPlaces(Number): 小数点后保留的位数，例如, `width: 100px` 中的100，将会被转换成 `Number(100 / divisor * multiple).toFixed(decimalPlaces)`
 - comment(String): 不转换px单位的注释，默认为 `/*no*/`。如果设置 comment 的值为 'not replace', `width: 100px; /* not replace */` 中的100px将不会被转换为 rpx。
+- disableAllComment(String): 不转换随后所有px单位的注释，默认为 `/*postcss-px2units-disable*/`。如果设置 disableAllComment 的值为 'not replace all', `width: 100px; /* not replace all */ height: 50px;` 中的50px将不会被转换为 rpx。
+- enableAllComment(String): 转换随后所有px单位的注释，默认为 `/*postcss-px2units-enable*/`。如果设置 enableAllComment 的值为 'replace all' 并设置 disableAllComment 为 'not replace all', `width: 100px; /* not replace all */ height: 50px; /* replace all */ margin: 10px;` 中的100px和10px将会被转换为rpx，50px将不会被转换为 rpx。
 - targetUnits(String): 转换单位，默认值为 rpx，如果设置其值为 'rem'，px将会被转换为rem。
 
 ### Use with gulp-postcss

--- a/index.js
+++ b/index.js
@@ -8,13 +8,16 @@ module.exports = postcss.plugin('postcss-px2units', function (opts) {
     multiple: 1,
     decimalPlaces: 2,
     targetUnits: 'rpx',
-    comment: 'no'
+    comment: 'no',
+    disableAllComment: 'postcss-px2units-disable',
+    enableAllComment: 'postcss-px2units-enable'
   }, opts);
 
   function repalcePx(str) {
     if (!str) {
       return '';
     }
+
     return str.replace(/\b(\d+(\.\d+)?)px\b/ig, function (match, x) {
       var size = x * opts.multiple / opts.divisor;
       return size % 1 === 0 ? size + opts.targetUnits : size.toFixed(opts.decimalPlaces) + opts.targetUnits;
@@ -22,11 +25,22 @@ module.exports = postcss.plugin('postcss-px2units', function (opts) {
   }
 
   return function (root) {
-    root.walkDecls(function (decl) {
-      if (decl && decl.next() && decl.next().type === 'comment' && decl.next().text === opts.comment) {
-        decl.next().remove();
-      } else {
-        decl.value = repalcePx(decl.value);
+    var enabled = true;
+    root.walk(function (item) {
+      if (item && item.type === 'decl' && enabled) {
+        if (item.next() && item.next().type === 'comment' && item.next().text === opts.comment) {
+          item.next().remove();
+        } else {
+          item.value = repalcePx(item.value);
+        }
+      } else if (item && item.type === 'comment') {
+        if (item.text === opts.disableAllComment) {
+          enabled = false;
+          item.remove();
+        } else if (item.text === opts.enableAllComment) {
+          enabled = true;
+          item.remove();
+        }
       }
     });
   };

--- a/test/test.js
+++ b/test/test.js
@@ -94,6 +94,27 @@ describe('postcss-px2units', () => {
     }, done)
   })
 
+  it('pixel values not replaced when disabled', (done) => {
+    test(`.title7 {
+      /* postcss-px2units-disable */
+      padding: 20rpx 30px 2rem 4em;
+      margin: 40px;
+      /* other comment is not removed */
+      font-size: 24px;
+      /* postcss-px2units-enable */
+      width: 60px;
+      /* postcss-px2units-disable */
+      height: 30px;
+    }`, `.title7 {
+      padding: 20rpx 30px 2rem 4em;
+      margin: 40px;
+      /* other comment is not removed */
+      font-size: 24px;
+      width: 60rpx;
+      height: 30px;
+    }`, {}, done)
+  })
+
   it('work in media', (done) => {
     test(`@media (-webkit-min-device-pixel-ratio: 2), (min-device-pixel-ratio: 2) {
       .word {


### PR DESCRIPTION
Make it possible to toggle `px` unit translations on and off for multiple declarations:

```css
.style-a {
  margin: 16px;
}
/* postcss-px2units-disable */
.style-b {
  padding: 48px;
}
/* postcss-px2units-enable */
.style-c {
  font-size: 24px;
}
```
is transformed to
```css
.style-a {
  margin: 16rpx;
}
.style-b {
  padding: 48px;
}
.style-c {
  font-size: 24rpx;
}
```

In some environments (such as many of the proprietary "miniprogram" runtimes), it may be desirable to style parts of a page with dimensions proportional to the page width and other parts with absolute "device pixel" dimensions. This can be done by using `px` and `rpx` units together. However, with the current version of postcss-px2units, a large number of `/* no */` comments is needed if the developer wants to do this on a page with postcss-px2units enabled. This change makes it more concise to use the two units together.